### PR TITLE
Update IterableLikeTest.java

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java
@@ -13,12 +13,7 @@
  */
 package org.jdbi.v3.core.internal;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -103,7 +98,7 @@ public class IterableLikeTest {
 
     @Test
     public void testSetToIterator() {
-        final Set<String> in = new HashSet<>(2);
+        final Set<String> in = new LinkedHashSet<>(2);
         in.add("1");
         in.add("2");
 


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[org.jdbi.v3.core.internal.IterableLikeTest#testSetToIterator ](https://github.com/jdbi/jdbi/blob/f1548d3ca12f3b82a91a9c4f740915f03fd6e45c/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java#L105)

Test Overview:
_________________________________________________________________________________________________________
In the above test, the set has been initialized as a HashSet which is non-deterministic in nature. It doesn't return the elements in the order in which they are stored.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
ERROR]   IterableLikeTest.testSetToIterator:112 
Actual and expected have the same elements but not in the same order, at index 0 actual element was:
  "2"
whereas expected element was:
  "1"
```

You can reproduce the issue by running the following commands:

```
mvn install -pl  core  -am -DskipTests
mvn test -pl katharsis-core  -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
mvn -pl katharsis-core edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I have changed the HashSet with LinkedHashSet which is deterministic in nature.

https://github.com/njain2208/jdbi/blob/e750efe826aaaed937cc98c87c27e30c08ce9b45/core/src/test/java/org/jdbi/v3/core/internal/IterableLikeTest.java#L101-L104