### PR TITLE
Update BeanMapperMockTest.java

### DIFF
--- a/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java
+++ b/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java
@@ -38,6 +38,7 @@ import org.mockito.quality.Strictness;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -231,9 +232,9 @@ public class BeanMapperMockTest {
     public void shouldThrowOnPropertyTypeWithoutRegisteredMapper() throws Exception {
         mockColumns("longField", "valueTypeField");
 
-        when(resultSet.getLong(1)).thenReturn(123L);
+        lenient().when(resultSet.getLong(1)).thenReturn(123L);
         when(resultSet.getObject(2)).thenReturn(new Object());
-        when(resultSet.wasNull()).thenReturn(false);
+        lenient().when(resultSet.wasNull()).thenReturn(false);
 
         assertThatThrownBy(() -> mapper.map(resultSet, ctx)).isInstanceOf(ClassCastException.class);
     }


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test:

[org.jdbi.v3.core.mapper.reflect.BeanMapperMockTest#shouldThrowOnPropertyTypeWithoutRegisteredMapper](https://github.com/njain2208/jdbi/blob/f1548d3ca12f3b82a91a9c4f740915f03fd6e45c/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java#L231-L240)

Test Overview:
_________________________________________________________________________________________________________
The error in the test is a result of using unnecessary stubbings in the test code. Unnecessary stubbings can clutter the code and make it less maintainable.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

You can reproduce the issue by running the following commands:

```
mvn install -pl katharsis-core -am -DskipTests
mvn test -pl katharsis-core  -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
mvn -pl katharsis-core edu.illinois:index-maven-plugin:2.1.1:nondex -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I decided to make the stubbing linenient. 

https://github.com/njain2208/jdbi/blob/f923a7c407164508446508b2c2cfac4760a6f2a6/core/src/test/java/org/jdbi/v3/core/mapper/reflect/BeanMapperMockTest.java#L232-L240